### PR TITLE
fix: non optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,10 +95,5 @@
     "@opentelemetry/resource-detector-container": "^0.3.0",
     "@opentelemetry/sdk-node": "^0.41.2",
     "@opentelemetry/sdk-trace-base": "^1.15.2"
-  },
-  "peerDependenciesMeta": {
-    "@nestjs/graphql": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
`@nestjs/graphql` was mark as optional, even if it was used in a non optional way.