### PR TITLE
Add basic exporter to span processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,11 +506,11 @@ export class AppModule {}
 // main.ts
 // at the very top of the file
 import { Tracing } from '@amplication/opentelemetry-nestjs';
-import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
 
 Tracing.init({
   serviceName: 'my-service',
-  spanProcessor: new SimpleSpanProcessor(),
+  spanProcessor: new SimpleSpanProcessor(new ConsoleSpanExporter()),
 });
 
 import { NestFactory } from '@nestjs/core';


### PR DESCRIPTION
`SimpleSpanProcessor` needs take an argument.
Current document cannot show span info directly.Add simple exporter thus developer can follow basic sample.